### PR TITLE
Add utility tests

### DIFF
--- a/src/input/normalizeWheel.spec.ts
+++ b/src/input/normalizeWheel.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import normalizeWheel from './normalizeWheel'
+
+describe('normalizeWheel', () => {
+  it('normalizes deltaX and deltaY', () => {
+    const event = { deltaX: 10, deltaY: -20, deltaMode: 0 }
+    const result = normalizeWheel(event)
+    expect(result.pixelX).toBe(10)
+    expect(result.pixelY).toBe(-20)
+    expect(result.spinX).toBe(1)
+    expect(result.spinY).toBe(-1)
+  })
+})

--- a/src/utils/defer.spec.ts
+++ b/src/utils/defer.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { defer, until } from './defer'
+
+// Basic test for defer functionality
+
+describe('defer', () => {
+  it('resolves with provided value', async () => {
+    const d = defer<number>()
+    setTimeout(() => d.resolve(42), 0)
+    await expect(d.promise).resolves.toBe(42)
+  })
+
+  it('rejects with provided reason', async () => {
+    const d = defer<number>()
+    setTimeout(() => d.reject(new Error('fail')), 0)
+    await expect(d.promise).rejects.toThrow('fail')
+  })
+})
+
+describe('until', () => {
+  it('resolves when condition becomes true', async () => {
+    let value = false
+    const rafMock = vi.fn((cb: FrameRequestCallback) => {
+      setTimeout(() => cb(0), 0)
+      return 0
+    })
+    vi.stubGlobal('requestAnimationFrame', rafMock)
+    setTimeout(() => {
+      value = true
+    }, 5)
+    await until(() => value)
+    expect(value).toBe(true)
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/utils/emitter.spec.ts
+++ b/src/utils/emitter.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { TypedEmitter } from './emitter'
+
+interface TestEvents {
+  foo: (value: number) => void
+  bar: () => void
+}
+
+describe('TypedEmitter', () => {
+  it('emits events to listeners', () => {
+    const emitter = new TypedEmitter<TestEvents>()
+    let called = 0
+    emitter.on('foo', (v) => { called = v })
+    emitter.emit('foo', 5)
+    expect(called).toBe(5)
+  })
+
+  it('removes listeners with off', () => {
+    const emitter = new TypedEmitter<TestEvents>()
+    const listener = () => {}
+    emitter.on('bar', listener)
+    emitter.off('bar', listener)
+    let triggered = false
+    emitter.on('bar', () => { triggered = true })
+    emitter.emit('bar')
+    expect(triggered).toBe(true)
+  })
+})

--- a/src/utils/math.spec.ts
+++ b/src/utils/math.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { vec3 } from 'gl-matrix'
+import * as THREE from 'three'
+import { lerp, lerpVec3, vec3ToThree, getAngle, getMeshCenter } from './math'
+
+describe('math utilities', () => {
+  it('lerp works correctly', () => {
+    expect(lerp(0, 10, 0.5)).toBe(5)
+  })
+
+  it('lerpVec3 interpolates vectors', () => {
+    const a = vec3.fromValues(0, 0, 0)
+    const b = vec3.fromValues(2, 2, 2)
+    const result = lerpVec3(a, b, 0.5)
+    expect(Array.from(result)).toEqual([1, 1, 1])
+  })
+
+  it('vec3ToThree converts correctly', () => {
+    const v = vec3.fromValues(1, 2, 3)
+    const t = vec3ToThree(v)
+    expect(t).toBeInstanceOf(THREE.Vector3)
+    expect(t.x).toBe(1)
+    expect(t.y).toBe(2)
+    expect(t.z).toBe(3)
+  })
+
+  it('getAngle calculates angle to camera', () => {
+    const object = new THREE.Vector3(1, 0, 0)
+    const player = new THREE.Vector3(0, 0, 0)
+    const camera = new THREE.PerspectiveCamera()
+    camera.position.set(0, 0, 0)
+    camera.lookAt(new THREE.Vector3(1, 0, 0))
+    const angle = getAngle(object, player, camera)
+    expect(angle).toBeCloseTo(0, 5)
+  })
+
+  it('getMeshCenter returns world center', () => {
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(2, 2, 2), new THREE.MeshBasicMaterial())
+    mesh.position.set(1, 2, 3)
+    const center = getMeshCenter(mesh)
+    expect(center.x).toBeCloseTo(1)
+    expect(center.y).toBeCloseTo(2)
+    expect(center.z).toBeCloseTo(3)
+  })
+})

--- a/src/utils/traverse.spec.ts
+++ b/src/utils/traverse.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import * as THREE from 'three'
+import { traverse, traverseParents } from './traverse'
+
+describe('traverse utilities', () => {
+  it('traverse yields all descendants', () => {
+    const root = new THREE.Object3D()
+    const child = new THREE.Object3D()
+    const grand = new THREE.Object3D()
+    child.add(grand)
+    root.add(child)
+    const list = Array.from(traverse(root))
+    expect(list).toHaveLength(3)
+    expect(list[0]).toBe(root)
+    expect(list[1]).toBe(child)
+    expect(list[2]).toBe(grand)
+  })
+
+  it('traverseParents yields parents up to root', () => {
+    const root = new THREE.Object3D()
+    const child = new THREE.Object3D()
+    root.add(child)
+    const parents = Array.from(traverseParents(child))
+    expect(parents).toEqual([root])
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for defer and until helpers
- cover TypedEmitter class behavior
- add math utility tests
- test traversal helpers
- verify wheel normalization logic

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6843ff37097083278912031abd0d1bbb